### PR TITLE
DateTime parsing in WabiSabiMonitorRpc.cs ParseInterval() fixing.

### DIFF
--- a/WabiSabiMonitor/Rpc/WabiSabiMonitorRpc.cs
+++ b/WabiSabiMonitor/Rpc/WabiSabiMonitorRpc.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using WabiSabiMonitor.Data;
 using WabiSabiMonitor.Rpc.Models;
 using WabiSabiMonitor.Utils.Logging;
@@ -43,15 +44,18 @@ public class WabiSabiMonitorRpc : IJsonRpcService
 	{
 		DateTime startDateTime = default;
 		DateTime endDateTime = default;
-		if(startTime != null && !DateTime.TryParse(startTime, out startDateTime))
+		
+		string[] formats = { "yyyy-MM-ddTHH:mm:ssZ", "MM/dd/yyyy HH:mm:ss" };
+		
+		if(startTime != null && !DateTime.TryParseExact(startTime, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out startDateTime))
 		{
 			throw new ArgumentException(
-				$"Couldn't parse start time: {startTime}. Suggested format: YYYY-MM-DDTHH:MM:SSZ");
+				$"Couldn't parse start time: {startTime}. Suggested formats: {string.Join(", ", formats)}");
 		}
-		if(endTime != null && !DateTime.TryParse(endTime, out endDateTime))
+		if(endTime != null && !DateTime.TryParseExact(endTime, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out endDateTime))
 		{
 			throw new ArgumentException(
-				$"Couldn't parse end time: {endTime}. Suggested format: YYYY-MM-DDTHH:MM:SSZ");
+				$"Couldn't parse end time: {endTime}. Suggested formats: {string.Join(", ", formats)}");
 		}
 
 		return (startDateTime, endDateTime);


### PR DESCRIPTION
If I am entering this type of format date into my json 2023-11-16T00:00:00Z, I can see that it's comming to
 `[JsonRpcMethod("get-rounds")]` as mm/dd/yyyy

![image](https://github.com/turbolay/WasabiMonitor/assets/107629187/83d364df-49be-40db-b9d7-c267409de0c4)

Before, there was always error, if we are entering 2023-11-16 format.
There are 2 parsing formats, so in the future we could easily choose correct one.

P.S.
I think force string date time format changing could be on Json parsing side. And I didn't want to change such fundamental things. This is fast fixing so we can use application.