### PR TITLE
Add RoundStateStoreManager to save ProcessedRounds daily

### DIFF
--- a/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
+++ b/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
@@ -9,13 +9,15 @@ public class ApplicationCore
     private readonly Scraper _roundStatusScraper;
     private readonly IRoundDataReaderService _dataProcessor;
     private readonly IRpcServerController _rpcServerController;
+    private readonly RoundStateStoreManager _roundStateStoreManager;
 
     public ApplicationCore(Scraper roundStatusScraper, IRoundDataReaderService dataProcessor,
-        IRpcServerController rpcServerController)
+        IRpcServerController rpcServerController, RoundStateStoreManager roundStateStoreManager)
     {
         _roundStatusScraper = roundStatusScraper;
         _dataProcessor = dataProcessor;
         _rpcServerController = rpcServerController;
+        _roundStateStoreManager = roundStateStoreManager;
     }
 
     public async Task Run(CancellationToken cancellationToken)
@@ -29,6 +31,8 @@ public class ApplicationCore
         await _roundStatusScraper.ToBeProcessedData.Reader.WaitToReadAsync(cancellationToken);
         Logger.LogInfo("Start round data reader service...");
         await _dataProcessor.StartAsync(cancellationToken);
+        Logger.LogInfo("Start round data saver...");
+        await _roundStateStoreManager.StartAsync(cancellationToken);
         Logger.LogInfo("Start rpc server controller...");
         await _rpcServerController.StartRpcServerAsync(cancellationToken);
         Logger.LogInfo("Initialized, ready to work.");

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Extensions.Hosting;
+using NBitcoin;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WabiSabiMonitor.ApplicationCore.Data;
+using WabiSabiMonitor.ApplicationCore.Interfaces;
+using WabiSabiMonitor.ApplicationCore.Utils.Bases;
+using WabiSabiMonitor.ApplicationCore.Utils.Helpers;
+using WabiSabiMonitor.ApplicationCore.Utils.Logging;
+using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Backend.Rounds;
+using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models.Serialization;
+
+namespace WabiSabiMonitor.ApplicationCore
+{
+    public class RoundStateStoreManager : BackgroundService
+    {
+        private readonly IRoundDataReaderService _roundDataReaderService;
+
+        public RoundStateStoreManager(IRoundDataReaderService roundDataReaderService)
+        {
+            _roundDataReaderService = roundDataReaderService;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                var date = DateTime.Now.Date;
+                var s = date.ToString("yyyy-MM-dd");
+                await WaitUntilMidnightAsync(stoppingToken);
+                Logger.LogInfo("It's midnight. Writing Daily Round States...");
+
+                Dictionary<uint256, RoundDataReaderService.ProcessedRound> allRounds = _roundDataReaderService.Rounds;
+                var roundsToday = allRounds.Where(x => x.Value.LastUpdate.Date == date).ToArray();
+
+                // Save finished rounds
+                var finishedRounds = roundsToday.Where(x => x.Value.Round.EndRoundState != EndRoundState.None).ToArray();
+
+                // If a BlameRound is still active, don't save its BlameOf.
+                var stillActiveBlameRoundsBlameOfIds = roundsToday.Where(x => x.Value.Round.EndRoundState == EndRoundState.None && x.Value.Round.IsBlame())
+                    .Select(x => x.Value.Round.BlameOf).ToArray();
+
+                var dataToWrite = finishedRounds.Where(round =>
+                {
+                    bool isBlameOf = stillActiveBlameRoundsBlameOfIds.Contains(round.Key);
+                    if (isBlameOf)
+                    {
+                        Logger.LogInfo($"Excluded Round {round.Key}, is BlameOf.");
+                    }
+
+                    return !isBlameOf;
+                }).ToArray();
+
+                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "Client")), $"RoundStates_{date:yyyy-MM-dd}.json");
+                File.WriteAllText(path, JsonConvert.SerializeObject(dataToWrite, JsonSerializationOptions.CurrentSettings));
+            }
+        }
+
+        private async Task WaitUntilMidnightAsync(CancellationToken stoppingToken)
+        {
+            var now = DateTime.Now.TimeOfDay;
+            TimeSpan midnight = new(0, 0, 0);
+
+            if (now > midnight)
+            {
+                midnight = midnight.Add(TimeSpan.FromDays(1));
+            }
+
+            var waitUntil = midnight - now;
+
+            await Task.Delay(waitUntil, stoppingToken);
+        }
+    }
+}

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -6,55 +6,54 @@ using WabiSabiMonitor.ApplicationCore.Interfaces;
 using WabiSabiMonitor.ApplicationCore.Utils.Helpers;
 using WabiSabiMonitor.ApplicationCore.Utils.Logging;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Backend.Rounds;
+using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models.Serialization;
 
 namespace WabiSabiMonitor.ApplicationCore
 {
     public class RoundStateStoreManager : BackgroundService
     {
-        private readonly IRoundDataReaderService _roundDataReaderService;
+        private readonly IRoundsDataFilter _roundsDataFilter;
 
-        public RoundStateStoreManager(IRoundDataReaderService roundDataReaderService)
+        public RoundStateStoreManager(IRoundsDataFilter roundsDataFilter)
         {
-            _roundDataReaderService = roundDataReaderService;
+            _roundsDataFilter = roundsDataFilter;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            List<KeyValuePair<uint256, RoundDataReaderService.ProcessedRound>> savedForNextDay = new();
+            List<RoundState> savedForNextDay = new();
             while (!stoppingToken.IsCancellationRequested)
             {
                 var date = DateTime.Now.Date;
                 await WaitUntilMidnightAsync(stoppingToken);
                 Logger.LogInfo("It's midnight. Writing Daily Round States...");
 
-                Dictionary<uint256, RoundDataReaderService.ProcessedRound> allRounds = _roundDataReaderService.Rounds;
-
                 // Get rounds that happened today.
-                var roundsToday = allRounds.Where(x => x.Value.LastUpdate.Date == date).ToList();
+                var roundsToday = _roundsDataFilter.GetRoundsInInterval(date, date.AddDays(1)).ToList();
 
                 // Add leftovers from yesterday.
                 roundsToday.AddRange(savedForNextDay);
                 savedForNextDay.Clear();
 
                 // Save finished rounds.
-                var finishedRounds = roundsToday.Where(x => x.Value.Round.EndRoundState != EndRoundState.None);
+                var finishedRounds = _roundsDataFilter.GetRoundsFinishedSince(date).ToArray();
 
                 // If a BlameRound is still active, don't save its BlameOf.
-                var stillActiveBlameRoundsBlameOfIds = roundsToday.Where(x => x.Value.Round.EndRoundState == EndRoundState.None && x.Value.Round.IsBlame())
-                    .Select(x => x.Value.Round.BlameOf);
+                var stillActiveBlameRoundsBlameOfIds = roundsToday.Where(x => x.EndRoundState == EndRoundState.None && x.IsBlame())
+                    .Select(x => x.BlameOf).ToArray();
 
                 var dataToWrite = finishedRounds.Where(round =>
                 {
-                    bool isBlameOf = stillActiveBlameRoundsBlameOfIds.Contains(round.Key);
+                    bool isBlameOf = stillActiveBlameRoundsBlameOfIds.Contains(round.Id);
                     if (isBlameOf)
                     {
-                        Logger.LogInfo($"Excluded Round {round.Key}, is BlameOf.");
+                        Logger.LogInfo($"Excluded Round {round.Id}, is BlameOf.");
                         savedForNextDay.Add(round);
                     }
 
                     return !isBlameOf;
-                });
+                }).ToArray();
 
                 var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "Client")), $"RoundStates_{date:yyyy-MM-dd}.json");
                 await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(dataToWrite, JsonSerializationOptions.CurrentSettings), stoppingToken);

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -32,6 +32,8 @@ namespace WabiSabiMonitor.ApplicationCore
 
                 // Get rounds that happened today.
                 var roundsToday = allRounds.Where(x => x.Value.LastUpdate.Date == date).ToList();
+
+                // Add leftovers from yesterday.
                 roundsToday.AddRange(savedForNextDay);
                 savedForNextDay.Clear();
 

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -1,15 +1,8 @@
 ﻿using Microsoft.Extensions.Hosting;
 using NBitcoin;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using WabiSabiMonitor.ApplicationCore.Data;
 using WabiSabiMonitor.ApplicationCore.Interfaces;
-using WabiSabiMonitor.ApplicationCore.Utils.Bases;
 using WabiSabiMonitor.ApplicationCore.Utils.Helpers;
 using WabiSabiMonitor.ApplicationCore.Utils.Logging;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Backend.Rounds;

--- a/WabiSabiMonitor/Program.cs
+++ b/WabiSabiMonitor/Program.cs
@@ -32,11 +32,9 @@ public static class Program
 
         var host = CreateHostBuilder(args).Build();
         var applicationCore = host.Services.GetRequiredService<ApplicationCore.ApplicationCore>();
-        var roundStateStoreManager = host.Services.GetRequiredService<RoundStateStoreManager>();
 
         try
         {
-            await roundStateStoreManager.StartAsync(CancellationTokenSource.Token);
             await applicationCore.Run(CancellationTokenSource.Token);
         }
         catch (Exception ex)

--- a/WabiSabiMonitor/Program.cs
+++ b/WabiSabiMonitor/Program.cs
@@ -32,9 +32,11 @@ public static class Program
 
         var host = CreateHostBuilder(args).Build();
         var applicationCore = host.Services.GetRequiredService<ApplicationCore.ApplicationCore>();
+        var roundStateStoreManager = host.Services.GetRequiredService<RoundStateStoreManager>();
 
         try
         {
+            await roundStateStoreManager.StartAsync(CancellationTokenSource.Token);
             await applicationCore.Run(CancellationTokenSource.Token);
         }
         catch (Exception ex)
@@ -119,6 +121,10 @@ public static class Program
                 var jsonRpcServerConfiguration = sp.GetRequiredService<JsonRpcServerConfiguration>();
 
                 return new RpcServerController(jsonRpcServer, jsonRpcServerConfiguration);
+            })
+            .AddSingleton<RoundStateStoreManager>(sp =>
+            {
+                return new RoundStateStoreManager(sp.GetRequiredService<IRoundDataReaderService>());
             })
             .AddSingleton<ApplicationCore.ApplicationCore>();
 

--- a/WabiSabiMonitor/Program.cs
+++ b/WabiSabiMonitor/Program.cs
@@ -120,10 +120,7 @@ public static class Program
 
                 return new RpcServerController(jsonRpcServer, jsonRpcServerConfiguration);
             })
-            .AddSingleton<RoundStateStoreManager>(sp =>
-            {
-                return new RoundStateStoreManager(sp.GetRequiredService<IRoundDataReaderService>());
-            })
+            .AddSingleton<RoundStateStoreManager>()
             .AddSingleton<ApplicationCore.ApplicationCore>();
 
         services.RemoveAll<IHttpMessageHandlerBuilderFilter>();


### PR DESCRIPTION
This PR adds the RoundStateStoreManager as a background service class, registers it as a service (not sure if needed) and starts it with ApplicationCore.
It runs in the background, waits until midnight, filters out rounds and writes them to file.

62cb9a40ea9034ad86f0187e7f67673aade945bd: Adding the class and wire it up.
7b5131587b970b86d2b48de1f9a4a22164251870: Tweak the code, remove unnecessary calls and saves unsaved BlameOf rounds for next day to save Blame and BlameOf rounds together.
59919f493b89090caebf8a7ab2a802b287ab87ce: Moved starting RoundStateStoreManager to ApplicationCore.
fff24afc0b02791f465bfc5bffa5ee4ddffa870e: Use RoundsDataFilter to simplify getting RoundStates.