### PR TITLE
Add AnalysisStoreManager to save Analysis periodically

### DIFF
--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -28,7 +28,7 @@ namespace WabiSabiMonitor.ApplicationCore
             TimeSpan startTime = TimeSpan.FromHours(24);
 
             var roundStates = _roundsDataFilter.GetRoundsStartedSince(startTime);
-            var analysis = _analyzer.AnalyzeRoundStates(roundStates, startTime);
+            var analysis = _analyzer.AnalyzeRoundStates(roundStates);
             if (analysis is null)
             {
                 return;

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.Extensions.Hosting;
+﻿using Newtonsoft.Json;
 using WabiSabiMonitor.ApplicationCore.Interfaces;
 using WabiSabiMonitor.ApplicationCore.Utils.Bases;
+using WabiSabiMonitor.ApplicationCore.Utils.Helpers;
+using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models.Serialization;
 
 namespace WabiSabiMonitor.ApplicationCore
 {
@@ -17,12 +19,13 @@ namespace WabiSabiMonitor.ApplicationCore
 
         protected override async Task ActionAsync(CancellationToken cancel)
         {
-            while (!cancel.IsCancellationRequested)
-            {
-                var date = DateTime.Now.Date;
-                var roundStates = _roundsDataFilter.GetRoundsStartedSince(date);
-                var analysis = _analyzer.AnalyzeRoundStates(roundStates);
-            }
+            var date = DateTime.Now.Date;
+            var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "Client")), $"Analysis_{date:yyyy-MM-dd}.json");
+
+            var roundStates = _roundsDataFilter.GetRoundsStartedSince(date);
+            var analysis = _analyzer.AnalyzeRoundStates(roundStates);
+
+            await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(analysis, JsonSerializationOptions.CurrentSettings), cancel);
         }
     }
 }

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -18,13 +18,13 @@ namespace WabiSabiMonitor.ApplicationCore
         {
             _analyzer = analyzer;
             _roundsDataFilter = roundsDataFilter;
-            _lastDate = DateTime.Now;
+            _lastDate = DateTime.UtcNow;
             Analysis = new();
         }
 
         protected override async Task ActionAsync(CancellationToken cancel)
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             TimeSpan startTime = TimeSpan.FromHours(24);
 
             var roundStates = _roundsDataFilter.GetRoundsStartedSince(startTime);

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -37,7 +37,7 @@ namespace WabiSabiMonitor.ApplicationCore
             if (now.Date != _lastDate.Date)
             {
                 // Save the last 24 hours data to file at the end of the day.
-                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "Analysis", "Client")), $"Analysis_{now:yyyy-MM-dd}.json");
+                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "Analysis")), $"Analysis_{_lastDate:yyyy-MM-dd}.json");
                 await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(analysis, JsonSerializationOptions.CurrentSettings), cancel);
 
                 // Remove data older than 15 days.

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -20,7 +20,7 @@ namespace WabiSabiMonitor.ApplicationCore
         protected override async Task ActionAsync(CancellationToken cancel)
         {
             var date = DateTime.Now.Date;
-            var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "Client")), $"Analysis_{date:yyyy-MM-dd}.json");
+            var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "Analysis", "Client")), $"Analysis_{date:yyyy-MM-dd}.json");
 
             var roundStates = _roundsDataFilter.GetRoundsStartedSince(date);
             var analysis = _analyzer.AnalyzeRoundStates(roundStates);

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Hosting;
+using WabiSabiMonitor.ApplicationCore.Interfaces;
+using WabiSabiMonitor.ApplicationCore.Utils.Bases;
+
+namespace WabiSabiMonitor.ApplicationCore
+{
+    public class AnalysisStoreManager : PeriodicRunner
+    {
+        private readonly IAnalyzer _analyzer;
+        private readonly IRoundsDataFilter _roundsDataFilter;
+
+        public AnalysisStoreManager(IAnalyzer analyzer, IRoundsDataFilter roundsDataFilter, TimeSpan period) : base(period)
+        {
+            _analyzer = analyzer;
+            _roundsDataFilter = roundsDataFilter;
+        }
+
+        protected override async Task ActionAsync(CancellationToken cancel)
+        {
+            while (!cancel.IsCancellationRequested)
+            {
+                var date = DateTime.Now.Date;
+                var roundStates = _roundsDataFilter.GetRoundsStartedSince(date);
+                var analysis = _analyzer.AnalyzeRoundStates(roundStates);
+            }
+        }
+    }
+}

--- a/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/AnalysisStoreManager.cs
@@ -18,6 +18,7 @@ namespace WabiSabiMonitor.ApplicationCore
         {
             _analyzer = analyzer;
             _roundsDataFilter = roundsDataFilter;
+            _lastDate = DateTime.Now;
             Analysis = new();
         }
 

--- a/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
+++ b/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
@@ -9,13 +9,15 @@ public class ApplicationCore
     private readonly Scraper _roundStatusScraper;
     private readonly IRoundDataReaderService _dataProcessor;
     private readonly IRpcServerController _rpcServerController;
+    private readonly AnalysisStoreManager _analysisStoreManager;
 
     public ApplicationCore(Scraper roundStatusScraper, IRoundDataReaderService dataProcessor,
-        IRpcServerController rpcServerController)
+        IRpcServerController rpcServerController, AnalysisStoreManager analysisStoreManager)
     {
         _roundStatusScraper = roundStatusScraper;
         _dataProcessor = dataProcessor;
         _rpcServerController = rpcServerController;
+        _analysisStoreManager = analysisStoreManager;
     }
 
     public async Task Run(CancellationToken cancellationToken)
@@ -29,6 +31,8 @@ public class ApplicationCore
         await _roundStatusScraper.ToBeProcessedData.Reader.WaitToReadAsync(cancellationToken);
         Logger.LogInfo("Start round data reader service...");
         await _dataProcessor.StartAsync(cancellationToken);
+        Logger.LogInfo("Start analysis data saver...");
+        await _analysisStoreManager.StartAsync(cancellationToken);
         Logger.LogInfo("Start rpc server controller...");
         await _rpcServerController.StartRpcServerAsync(cancellationToken);
         Logger.LogInfo("Initialized, ready to work.");

--- a/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
+++ b/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
@@ -6,6 +6,8 @@ namespace WabiSabiMonitor.ApplicationCore;
 
 public class ApplicationCore
 {
+    public static DateTime LastInit { get; } = DateTime.UtcNow;
+    
     private readonly Scraper _roundStatusScraper;
     private readonly IRoundDataReaderService _dataProcessor;
     private readonly IRpcServerController _rpcServerController;

--- a/WabiSabiMonitor.ApplicationCore/BetterHumanMonitor.cs
+++ b/WabiSabiMonitor.ApplicationCore/BetterHumanMonitor.cs
@@ -23,8 +23,11 @@ public class BetterHumanMonitor : IBetterHumanMonitor
         _roundDataReaderService = roundDataReaderService;
     }
 
-    public BetterHumanMonitorModel GetApiResponse(DateTimeOffset? start = null, DateTimeOffset? end = null)
+    public BetterHumanMonitorModel GetApiResponse(TimeSpan? durationNullable = null)
     {
+        var duration = durationNullable ?? TimeSpan.FromHours(12);
+        DateTimeOffset start = DateTimeOffset.UtcNow - duration;
+        
         var result = BetterHumanMonitorModel.Empty();
 
         BetterHumanMonitorRound CreateBetterHumanMonitorRound(RoundState round)
@@ -54,7 +57,7 @@ public class BetterHumanMonitor : IBetterHumanMonitor
                 currentFeesConditions);
         }
 
-        var allRoundsInInterval = _roundDataFilter.GetRoundsInInterval(start, end);
+        var allRoundsInInterval = _roundDataFilter.GetRoundsInInterval(start, null);
 
         var currentRounds = _roundDataFilter.GetCurrentRounds();
         foreach (var current in currentRounds)

--- a/WabiSabiMonitor.ApplicationCore/BetterHumanMonitor.cs
+++ b/WabiSabiMonitor.ApplicationCore/BetterHumanMonitor.cs
@@ -57,16 +57,13 @@ public class BetterHumanMonitor : IBetterHumanMonitor
                 currentFeesConditions);
         }
 
-        var allRoundsInInterval = _roundDataFilter.GetRoundsInInterval(start, null);
-
         var currentRounds = _roundDataFilter.GetCurrentRounds();
         foreach (var current in currentRounds)
         {
             result.CurrentRounds.Add(CreateBetterHumanMonitorRound(current));
         }
-
-        var lastPeriodRounds = allRoundsInInterval.Where(x => !currentRounds.Select(y => y.Id).Contains(x.Id)).ToList();
-
+        
+        var lastPeriodRounds = _roundDataFilter.GetRoundsFinishedInInterval(start, null);
         foreach (var lastPeriodRound in lastPeriodRounds)
         {
             result.LastPeriod.Add(CreateBetterHumanMonitorRound(lastPeriodRound));

--- a/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
@@ -17,14 +17,15 @@ public class Analyzer : IAnalyzer
         _roundsDataFilter = roundsDataFilter;
     }
 
-    public Analysis? AnalyzeRoundStates(List<RoundState> roundStates, TimeSpan intervalDuration)
+    public Analysis? AnalyzeRoundStates(List<RoundState> roundStates)
     {
         if (!roundStates.Any())
         {
             return null;
         }
 
-        var (Start, End) = GetInterval(roundStates);
+        var (start, end) = GetInterval(roundStates);
+        var intervalDuration = end - start;
 
         decimal averageFeeRate = 0;
         decimal nbOutputPerInput = 0;
@@ -55,8 +56,8 @@ public class Analyzer : IAnalyzer
             roundStates.Sum(x => _roundsDataFilter.GetNbBanEstimation(x)) / intervalDuration.TotalHours;
 
         return new Analysis(
-            Start,
-            End,
+            start,
+            end,
             inputsPerHour,
             btcPerHour,
             blameRoundsPerHour,

--- a/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
@@ -3,6 +3,7 @@ using WabiSabiMonitor.ApplicationCore.Interfaces;
 using WabiSabiMonitor.ApplicationCore.Utils.Extensions;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Backend.Rounds;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models;
+using Xunit.Sdk;
 
 namespace WabiSabiMonitor.ApplicationCore.Data;
 
@@ -24,8 +25,13 @@ public class Analyzer : IAnalyzer
             return null;
         }
 
+        roundStates = new List<RoundState> { roundStates.First() };
         var (Start, End) = GetInterval(roundStates);
         var intervalDuration = (End - Start);
+        if (intervalDuration == TimeSpan.Zero)
+        {
+            intervalDuration = new TimeSpan(1, 0, 0);
+        }
 
         decimal averageFeeRate = 0;
         decimal nbOutputPerInput = 0;

--- a/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
@@ -25,7 +25,6 @@ public class Analyzer : IAnalyzer
             return null;
         }
 
-        roundStates = new List<RoundState> { roundStates.First() };
         var (Start, End) = GetInterval(roundStates);
         var intervalDuration = (End - Start);
         if (intervalDuration == TimeSpan.Zero)

--- a/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
@@ -3,7 +3,6 @@ using WabiSabiMonitor.ApplicationCore.Interfaces;
 using WabiSabiMonitor.ApplicationCore.Utils.Extensions;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Backend.Rounds;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models;
-using Xunit.Sdk;
 
 namespace WabiSabiMonitor.ApplicationCore.Data;
 

--- a/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/Analyzer.cs
@@ -17,7 +17,7 @@ public class Analyzer : IAnalyzer
         _roundsDataFilter = roundsDataFilter;
     }
 
-    public Analysis? AnalyzeRoundStates(List<RoundState> roundStates)
+    public Analysis? AnalyzeRoundStates(List<RoundState> roundStates, TimeSpan intervalDuration)
     {
         if (!roundStates.Any())
         {
@@ -25,11 +25,6 @@ public class Analyzer : IAnalyzer
         }
 
         var (Start, End) = GetInterval(roundStates);
-        var intervalDuration = (End - Start);
-        if (intervalDuration == TimeSpan.Zero)
-        {
-            intervalDuration = new TimeSpan(1, 0, 0);
-        }
 
         decimal averageFeeRate = 0;
         decimal nbOutputPerInput = 0;

--- a/WabiSabiMonitor.ApplicationCore/Interfaces/IAnalyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Interfaces/IAnalyzer.cs
@@ -5,5 +5,5 @@ namespace WabiSabiMonitor.ApplicationCore.Interfaces;
 
 public interface IAnalyzer
 {
-    Analyzer.Analysis? AnalyzeRoundStates(List<RoundState> roundStates);
+    Analyzer.Analysis? AnalyzeRoundStates(List<RoundState> roundStates, TimeSpan interval = default);
 }

--- a/WabiSabiMonitor.ApplicationCore/Interfaces/IAnalyzer.cs
+++ b/WabiSabiMonitor.ApplicationCore/Interfaces/IAnalyzer.cs
@@ -5,5 +5,5 @@ namespace WabiSabiMonitor.ApplicationCore.Interfaces;
 
 public interface IAnalyzer
 {
-    Analyzer.Analysis? AnalyzeRoundStates(List<RoundState> roundStates, TimeSpan interval = default);
+    Analyzer.Analysis? AnalyzeRoundStates(List<RoundState> roundStates);
 }

--- a/WabiSabiMonitor.ApplicationCore/Interfaces/IBetterHumanMonitor.cs
+++ b/WabiSabiMonitor.ApplicationCore/Interfaces/IBetterHumanMonitor.cs
@@ -4,5 +4,5 @@ namespace WabiSabiMonitor.ApplicationCore.Interfaces;
 
 public interface IBetterHumanMonitor
 {
-    BetterHumanMonitorModel GetApiResponse(DateTimeOffset? start = null, DateTimeOffset? end = null);
+    BetterHumanMonitorModel GetApiResponse(TimeSpan? duration = null);
 }

--- a/WabiSabiMonitor.ApplicationCore/Interfaces/IRoundsDataFilter.cs
+++ b/WabiSabiMonitor.ApplicationCore/Interfaces/IRoundsDataFilter.cs
@@ -5,7 +5,7 @@ namespace WabiSabiMonitor.ApplicationCore.Interfaces;
 
 public interface IRoundsDataFilter
 {
-    List<RoundState> GetRoundsInInterval(DateTimeOffset? start, DateTimeOffset? end, Func<RoundState, bool>? predicate = null);
+    List<RoundState> GetRoundsFinishedInInterval(DateTimeOffset? start, DateTimeOffset? end, Func<RoundState, bool>? predicate = null);
 
     List<RoundState> GetCurrentRounds();
 

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -25,7 +25,7 @@ namespace WabiSabiMonitor.ApplicationCore
             List<RoundState> savedForNextDay = new();
             while (!stoppingToken.IsCancellationRequested)
             {
-                var date = DateTime.Now.Date;
+                var date = DateTime.UtcNow.Date;
                 await WaitUntilMidnightAsync(stoppingToken);
                 Logger.LogInfo("It's midnight. Writing Daily Round States...");
 
@@ -62,7 +62,7 @@ namespace WabiSabiMonitor.ApplicationCore
 
         private async Task WaitUntilMidnightAsync(CancellationToken stoppingToken)
         {
-            var now = DateTime.Now.TimeOfDay;
+            var now = DateTime.UtcNow.TimeOfDay;
             TimeSpan midnight = new(0, 0, 0);
 
             if (now > midnight)

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -55,7 +55,7 @@ namespace WabiSabiMonitor.ApplicationCore
                     return !isBlameOf;
                 }).ToArray();
 
-                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "Client")), $"RoundStates_{date:yyyy-MM-dd}.json");
+                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "RoundState", "Client")), $"RoundStates_{date:yyyy-MM-dd}.json");
                 await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(dataToWrite, JsonSerializationOptions.CurrentSettings), stoppingToken);
             }
         }

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -55,7 +55,7 @@ namespace WabiSabiMonitor.ApplicationCore
                     return !isBlameOf;
                 }).ToArray();
 
-                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "RoundState", "Client")), $"RoundStates_{date:yyyy-MM-dd}.json");
+                var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "RoundState")), $"RoundStates_{date:yyyy-MM-dd}.json");
                 await File.WriteAllTextAsync(path, JsonConvert.SerializeObject(dataToWrite, JsonSerializationOptions.CurrentSettings), stoppingToken);
             }
         }

--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -30,29 +30,33 @@ namespace WabiSabiMonitor.ApplicationCore
                 Logger.LogInfo("It's midnight. Writing Daily Round States...");
 
                 // Get rounds that happened today.
-                var roundsToday = _roundsDataFilter.GetRoundsInInterval(date, date.AddDays(1)).ToList();
+                var roundsToday = _roundsDataFilter.GetRoundsFinishedInInterval(date, date.AddDays(1)).ToList();
 
                 // Add leftovers from yesterday.
                 roundsToday.AddRange(savedForNextDay);
                 savedForNextDay.Clear();
 
-                // Save finished rounds.
-                var finishedRounds = _roundsDataFilter.GetRoundsFinishedSince(date).ToArray();
-
-                // If a BlameRound is still active, don't save its BlameOf.
-                var stillActiveBlameRoundsBlameOfIds = roundsToday.Where(x => x.EndRoundState == EndRoundState.None && x.IsBlame())
-                    .Select(x => x.BlameOf).ToArray();
-
-                var dataToWrite = finishedRounds.Where(round =>
+                // If a BlameRound is still active, don't save the chain of blame
+                var stillActiveBlameRoundsBlameOfIds = new List<uint256>();
+                foreach (var onGoingRound in _roundsDataFilter.GetCurrentRounds())
                 {
-                    bool isBlameOf = stillActiveBlameRoundsBlameOfIds.Contains(round.Id);
-                    if (isBlameOf)
+                    var currentRound = onGoingRound;
+                    while (currentRound.IsBlame())
                     {
-                        Logger.LogInfo($"Excluded Round {round.Id}, is BlameOf.");
-                        savedForNextDay.Add(round);
+                        var blameOf = roundsToday.FirstOrDefault(x => x.Id == currentRound.Id);
+                        if (blameOf is null) break;
+                        stillActiveBlameRoundsBlameOfIds.Add(currentRound.Id);
+                        currentRound = blameOf;
                     }
+                }
 
-                    return !isBlameOf;
+                var dataToWrite = roundsToday.Where(round =>
+                {
+                    var isBlameOf = stillActiveBlameRoundsBlameOfIds.Contains(round.Id);
+                    if (!isBlameOf) return true;
+                    Logger.LogDebug($"Excluded Round {round.Id}, because its chain of Blame is still active.");
+                    savedForNextDay.Add(round);
+                    return false;
                 }).ToArray();
 
                 var path = Path.Combine(EnvironmentHelpers.GetDataDir(Path.Combine("WabiSabiMonitor", "DataStore", "RoundState")), $"RoundStates_{date:yyyy-MM-dd}.json");

--- a/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
+++ b/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
@@ -41,7 +41,7 @@ public class WabiSabiMonitorRpc : IJsonRpcService
             startDateTime = DateTime.UtcNow - TimeSpan.FromHours(12);
         }
 
-        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsInInterval(startDateTime, endDateTime));
+        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsInInterval(startDateTime, endDateTime), endDateTime - startDateTime);
     }
 
     [JsonRpcMethod("get-rounds")]
@@ -67,7 +67,7 @@ public class WabiSabiMonitorRpc : IJsonRpcService
         {
             throw new ArgumentException($"Couldn't parse end time: {endTime}. Suggested formats: {string.Join(", ", formats)}");
         }
-        
+
         return (startDateTime, endDateTime);
     }
 }

--- a/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
+++ b/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
@@ -21,14 +21,6 @@ public class WabiSabiMonitorRpc : IJsonRpcService
         _betterHumanMonitor = betterHumanMonitor;
     }
 
-    [JsonRpcMethod("echo")]
-    public string HelloWorld()
-    {
-        var message = "Hello world!";
-        Logger.LogInfo(message);
-        return message;
-    }
-
     [JsonRpcMethod("better-human-monitor")]
     public BetterHumanMonitorModel GetBetterHumanMonitor() => _betterHumanMonitor.GetApiResponse();
 
@@ -41,16 +33,9 @@ public class WabiSabiMonitorRpc : IJsonRpcService
             startDateTime = DateTime.UtcNow - TimeSpan.FromHours(12);
         }
 
-        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsInInterval(startDateTime, endDateTime));
+        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsFinishedInInterval(startDateTime, endDateTime));
     }
-
-    [JsonRpcMethod("get-rounds")]
-    public List<RoundState> GetRounds(string? startTime = null, string? endTime = null)
-    {
-        var (startDateTime, endDateTime) = ParseInterval(startTime, endTime);
-        return _filter.GetRoundsInInterval(startDateTime, endDateTime);
-    }
-
+    
     private static (DateTime, DateTime) ParseInterval(string? startTime, string? endTime)
     {
         DateTime startDateTime = default;

--- a/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
+++ b/WabiSabiMonitor.ApplicationCore/Rpc/WabiSabiMonitorRpc.cs
@@ -41,7 +41,7 @@ public class WabiSabiMonitorRpc : IJsonRpcService
             startDateTime = DateTime.UtcNow - TimeSpan.FromHours(12);
         }
 
-        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsInInterval(startDateTime, endDateTime), endDateTime - startDateTime);
+        return _analyzer.AnalyzeRoundStates(_filter.GetRoundsInInterval(startDateTime, endDateTime));
     }
 
     [JsonRpcMethod("get-rounds")]

--- a/WabiSabiMonitor/Program.cs
+++ b/WabiSabiMonitor/Program.cs
@@ -120,6 +120,7 @@ public static class Program
 
                 return new RpcServerController(jsonRpcServer, jsonRpcServerConfiguration);
             })
+            .AddSingleton<AnalysisStoreManager>(sp => new AnalysisStoreManager(sp.GetRequiredService<IAnalyzer>(), sp.GetRequiredService<IRoundsDataFilter>(), TimeSpan.FromMinutes(10)))
             .AddSingleton<ApplicationCore.ApplicationCore>();
 
         services.RemoveAll<IHttpMessageHandlerBuilderFilter>();


### PR DESCRIPTION
This PR adds a new class/service, AnalysisStoreManager, a `PeriodicRunner`, which runs every 10 minutes, calls `Analyzer.AnalyzeRoundStates()`, and saves the Analysis in the data folder.
If an Analysis already exists for that day, it gets overwritten with the new data.

9bef6011109f17578c90698ae64662c03a8169d5 & 5aacfe315e44cda3395d9193ef6217d4e7be60b8: Add AnalysisStoreManager and write it's ActionAsync.
dcd18c8e3bbe39399f199d7421133f50bb03c282: If only 1 round state exists, `intervalDuration` will be 0, and will cause `DivideByZero` exception during calculation. In that case I set a 1 hour TimeSpan default.