### PR TITLE
Move Logger init to Program.cs

### DIFF
--- a/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
+++ b/WabiSabiMonitor.ApplicationCore/ApplicationCore.cs
@@ -22,8 +22,6 @@ public class ApplicationCore
 
     public async Task Run(CancellationToken cancellationToken)
     {
-        Logger.InitializeDefaults("./logs.txt");
-
         Logger.LogInfo("Starting scraper...");
         await _roundStatusScraper.StartAsync(cancellationToken);
         await _roundStatusScraper.TriggerAndWaitRoundAsync(cancellationToken);

--- a/WabiSabiMonitor.ApplicationCore/Data/FileProcessedRoundRepository.cs
+++ b/WabiSabiMonitor.ApplicationCore/Data/FileProcessedRoundRepository.cs
@@ -1,6 +1,7 @@
 using NBitcoin;
 using Newtonsoft.Json;
 using WabiSabiMonitor.ApplicationCore.Interfaces;
+using WabiSabiMonitor.ApplicationCore.Utils.Logging;
 using WabiSabiMonitor.ApplicationCore.Utils.WabiSabi.Models.Serialization;
 
 namespace WabiSabiMonitor.ApplicationCore.Data;
@@ -24,6 +25,7 @@ public class FileProcessedRoundRepository : IProcessedRoundRepository
     {
         try
         {
+            Logger.LogInfo("Reading RoundStates from file...");
             return JsonConvert.DeserializeObject<Dictionary<uint256, RoundDataReaderService.ProcessedRound>>(
                 File.ReadAllText(_path), JsonSerializationOptions.CurrentSettings);
         }

--- a/WabiSabiMonitor/Program.cs
+++ b/WabiSabiMonitor/Program.cs
@@ -28,6 +28,7 @@ public static class Program
 
     public static async Task Main(string[] args)
     {
+        Logger.InitializeDefaults("./logs.txt");
         HandleClosure();
 
         var host = CreateHostBuilder(args).Build();


### PR DESCRIPTION
Moved `Logger.InitializeDefaults("./logs.txt");` lines from `ApplicationCore` to `Program` for better logging even before creating `ApplicationCore`.

Found this usefull as I achieved a 1GB data.json, which takes a long time to deserialize, so when I started the software, I saw nothing but a blank terminal. Thought my commits screw something up. So I added a log there as well.