### PR TITLE
Fix calculation of BlameOf chain

### DIFF
--- a/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
+++ b/WabiSabiMonitor.ApplicationCore/RoundStateStoreManager.cs
@@ -43,9 +43,9 @@ namespace WabiSabiMonitor.ApplicationCore
                     var currentRound = onGoingRound;
                     while (currentRound.IsBlame())
                     {
-                        var blameOf = roundsToday.FirstOrDefault(x => x.Id == currentRound.Id);
+                        var blameOf = roundsToday.FirstOrDefault(x => x.Id == currentRound.BlameOf);
                         if (blameOf is null) break;
-                        stillActiveBlameRoundsBlameOfIds.Add(currentRound.Id);
+                        stillActiveBlameRoundsBlameOfIds.Add(blameOf.Id);
                         currentRound = blameOf;
                     }
                 }


### PR DESCRIPTION
Saw the changes in 087c693939d739ef471cfdde5b589355202aa5f4, but the `BlameOf` chain calculation part was not working, while a Blame round was ongoing, it's `BlameOf` round was in `dataToWrite` and was not added to `saveForNextDay.
This PR fixes this.